### PR TITLE
input: touchscreen: use -EPROBE_DEFER when panel not ready

### DIFF
--- a/drivers/input/touchscreen/chipone_tddi_fhd_mmi/cts_i2c_driver.c
+++ b/drivers/input/touchscreen/chipone_tddi_fhd_mmi/cts_i2c_driver.c
@@ -485,7 +485,7 @@ static int cts_driver_probe(struct spi_device *client)
 			if (!check_default_tp(dp, "qcom,i2c-touch-active"))
 				ret = -EPROBE_DEFER;
 			else
-				ret = -ENODEV;
+				ret = -EPROBE_DEFER;
 
 			cts_err("%s: %s not actived\n", __func__, dp->name);
 			return ret;

--- a/drivers/input/touchscreen/chipone_tddi_mmi/cts_i2c_driver.c
+++ b/drivers/input/touchscreen/chipone_tddi_mmi/cts_i2c_driver.c
@@ -286,7 +286,7 @@ static int cts_driver_probe(struct spi_device *client)
     if (!check_default_tp(dp, "qcom,i2c-touch-active"))
         ret = -EPROBE_DEFER;
     else
-        ret = -ENODEV;
+        ret = -EPROBE_DEFER;
 
 		cts_err("%s: %s not actived\n", __func__, dp->name);
     return ret;

--- a/drivers/input/touchscreen/chipone_tddi_v2_mmi/cts_driver.c
+++ b/drivers/input/touchscreen/chipone_tddi_v2_mmi/cts_driver.c
@@ -674,7 +674,7 @@ static int cts_driver_probe(struct spi_device *client)
             if (!check_default_tp(dp, "qcom,i2c-touch-active"))
                 ret = -EPROBE_DEFER;
             else
-                ret = -ENODEV;
+                ret = -EPROBE_DEFER;
 
             cts_err("%s: %s not actived\n", __func__, dp->name);
             return ret;

--- a/drivers/input/touchscreen/ilitek_v3_mmi/ilitek_v3_qcom.c
+++ b/drivers/input/touchscreen/ilitek_v3_mmi/ilitek_v3_qcom.c
@@ -969,7 +969,7 @@ static int ilitek_plat_probe(void)
 	ret = ili_v3_drm_check_dt(ilits->dev->of_node);
 	if (ret) {
 		ILI_ERR("[ili_v3_drm_check_dt] parse drm-panel fail");
-		return ret;
+		return -EPROBE_DEFER;
 	}
 #endif
 #endif


### PR DESCRIPTION
When the DSI panel driver hasn't registered yet, the chipone and ilitek touch drivers return -ENODEV (permanent failure) instead of -EPROBE_DEFER (retry). With Clang 12 (SushiKernel's pinned toolchain) the panel probes first, so this is latent — but Clang 20+ reverses probe ordering, causing the touch driver to fail permanently.

Fix all three chipone variants and the ilitek v3 driver to return -EPROBE_DEFER when the panel dependency is not ready.